### PR TITLE
use strict mode

### DIFF
--- a/src/bridge.js
+++ b/src/bridge.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict'
 /** allow to use Elm from nodejs...
  */
 const path = require('path')

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -1,3 +1,4 @@
+"use strict";
 /** allow to use Elm from nodejs...
  */
 const path = require('path')


### PR DESCRIPTION
This PR resolves following run time error.

```
node/node-v4.6.1-linux-x64/lib/node_modules/elm-doctest/src/bridge.js:41
let elmfile = ''
^^^

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
```
